### PR TITLE
Better usage of empty spaces

### DIFF
--- a/css/layout.css
+++ b/css/layout.css
@@ -22,5 +22,9 @@
 }
 
 #board.layout-trello-mixed .list-wrapper {
-    max-height: 45%;
+    height:	auto;
+}
+
+#board.layout-trello-mixed .js-list-content {
+    max-height: 42vh;
 }


### PR DESCRIPTION
Rows in mixed view are only as high as the tallest list within the row, for better usage of screen real estate.

Using 'vh' because there is no support for '%' height of a parent element with 'auto' height.