### PR TITLE
Default to mixed layout

### DIFF
--- a/contentscript.js
+++ b/contentscript.js
@@ -51,6 +51,7 @@ function readyCheck() {
     if (!btnView && btnNotifications) {
         insertButton();
         insertCss();
+        board.classList.add(classMixed);
         clearInterval(timer);
     }
 }


### PR DESCRIPTION
Make mixed layout the default on load (assuming everyone is using this extension because they didn't want the default Trello layout)

A better solution in the future would be to 'remember' the user's last used layout.