### PR TITLE
Save last layout locally

### DIFF
--- a/contentscript.js
+++ b/contentscript.js
@@ -21,12 +21,15 @@ function toggleView() {
     if (!board.classList.contains(classMixed)) {
         if (!board.classList.contains(classVertical)) {
             board.classList.add(classMixed);
+            chrome.storage.sync.set({'classList': classMixed});
         } else {
             board.classList.remove(classVertical);
+            chrome.storage.sync.remove('classList');
         }
     } else {
         board.classList.remove(classMixed);
         board.classList.add(classVertical);
+        chrome.storage.sync.set({'classList': classVertical});
     }
 }
 
@@ -51,6 +54,11 @@ function readyCheck() {
     if (!btnView && btnNotifications) {
         insertButton();
         insertCss();
+        chrome.storage.sync.get('classList', function (result) {
+            if(result.classList){
+                board.classList.add(result.classList);
+            }
+        });
         clearInterval(timer);
     }
 }

--- a/css/layout.css
+++ b/css/layout.css
@@ -19,8 +19,9 @@
 #board.layout-trello-vertical .list-wrapper,
 #board.layout-trello-mixed .list-wrapper {
     margin: 0 0 10px 10px;
+    height: auto;
 }
 
-#board.layout-trello-mixed .list-wrapper {
-    max-height: 45%;
+#board.layout-trello-mixed .js-list-content {
+    max-height: 40vh;
 }

--- a/manifest.json
+++ b/manifest.json
@@ -21,7 +21,7 @@
   },
   
   "permissions": [
-    "*://trello.com/*", "tabs", "webNavigation"
+    "*://trello.com/*", "tabs", "webNavigation", "storage"
   ],
 	
 	"web_accessible_resources": [


### PR DESCRIPTION
The user's last layout choice is saved across sessions, and reloaded when Trello is visited again.

The CSS also includes a better way of laying out Mixed view so there is no extra white space. If the lists are short the user can see more than 2 rows.
